### PR TITLE
CNX-1786 Implement logic for creating custom exchange

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule MessageQueue.MixProject do
   use Mix.Project
 
   @name "MessageQueue"
-  @version "0.1.8"
+  @version "0.1.9"
   @repo_url "https://github.com/ChannexIO/message_queue"
 
   def project do


### PR DESCRIPTION
Producing:
```
MessageQueue.Producer.publish(payload, "", [persistent: true, exchange: "x-live-feed-exchange", exchange_type: "fanout"])
```

Consuming:
```
  @queue "test_worker"

  @spec start_link(binary) :: {:ok, pid}
  def start_link(_) do
    GenServer.start_link(
      __MODULE__,
      %{
        queue: @queue,
        prefetch_count: 1,
        bindings: [{"x-live-feed-exchange", [queue: @queue]}]
      },
      name: __MODULE__
    )
  end

  def handle_message(mail_message, meta, state) do
       ...
  end
```