### PR TITLE
Migrate to :erlang.term_to_binary/1 and :erlang.binary_to_term/1 in RabbitMQ.RPCClient

### DIFF
--- a/lib/message_queue/rpc_client/request.ex
+++ b/lib/message_queue/rpc_client/request.ex
@@ -13,7 +13,7 @@ defmodule MessageQueue.RPCClient.Request do
   end
 
   defp encode_command(command) do
-    Jason.encode(command)
+    {:ok, :erlang.term_to_binary(command)}
   end
 
   defp get_correlation_id do

--- a/lib/message_queue/rpc_client/response.ex
+++ b/lib/message_queue/rpc_client/response.ex
@@ -5,16 +5,6 @@ defmodule MessageQueue.RPCClient.Response do
 
   @spec prepare!(payload :: binary) :: term()
   def prepare!(payload) do
-    payload
-    |> Jason.decode!()
-    |> case do
-      ["ok" | tail] -> response_tuple(:ok, tail)
-      ["error" | tail] -> response_tuple(:error, tail)
-      value -> value
-    end
-  end
-
-  defp response_tuple(resolution, tail) do
-    List.to_tuple(tail) |> Tuple.insert_at(0, resolution)
+    :erlang.binary_to_term(payload, [:safe])
   end
 end


### PR DESCRIPTION
This will simplify interaction between client and server but maybe dangerous because no sanity checks is not performed. We should consider to use `:erlang.binary_to_term/2` with `:safe` option but it needs more testing 
(edit: safe option is added)