### PR TITLE
Revert "Migrate to encode/decode request/response by :erlang.term_to_binary/1 and :erlang.binary_to_term/1 in RabbitMQ.RPCClient"

### DIFF
--- a/lib/message_queue/rpc_client/request.ex
+++ b/lib/message_queue/rpc_client/request.ex
@@ -13,7 +13,7 @@ defmodule MessageQueue.RPCClient.Request do
   end
 
   defp encode_command(command) do
-    {:ok, :erlang.term_to_binary(command)}
+    Jason.encode(command)
   end
 
   defp get_correlation_id do

--- a/lib/message_queue/rpc_client/response.ex
+++ b/lib/message_queue/rpc_client/response.ex
@@ -5,6 +5,16 @@ defmodule MessageQueue.RPCClient.Response do
 
   @spec prepare!(payload :: binary) :: term()
   def prepare!(payload) do
-    :erlang.binary_to_term(payload, [:safe])
+    payload
+    |> Jason.decode!()
+    |> case do
+      ["ok" | tail] -> response_tuple(:ok, tail)
+      ["error" | tail] -> response_tuple(:error, tail)
+      value -> value
+    end
+  end
+
+  defp response_tuple(resolution, tail) do
+    List.to_tuple(tail) |> Tuple.insert_at(0, resolution)
   end
 end


### PR DESCRIPTION
This reverts commit b36782ed3927f3407beb69e5d85aa1a0ffa8778c.