### PR TITLE
Use non_executable_binary_to_term in RabbitMQ.RPCClient

### DIFF
--- a/lib/message_queue/rpc_client/response.ex
+++ b/lib/message_queue/rpc_client/response.ex
@@ -5,6 +5,60 @@ defmodule MessageQueue.RPCClient.Response do
 
   @spec prepare!(payload :: binary) :: term()
   def prepare!(payload) do
-    :erlang.binary_to_term(payload, [:safe])
+    non_executable_binary_to_term(payload)
+  end
+
+  defp non_executable_binary_to_term(binary, opts \\ []) when is_binary(binary) do
+    term = :erlang.binary_to_term(binary, opts)
+    non_executable_terms(term)
+    term
+  end
+
+  defp non_executable_terms(list) when is_list(list) do
+    non_executable_list(list)
+  end
+
+  defp non_executable_terms(tuple) when is_tuple(tuple) do
+    non_executable_tuple(tuple, tuple_size(tuple))
+  end
+
+  defp non_executable_terms(map) when is_map(map) do
+    folder = fn key, value, acc ->
+      non_executable_terms(key)
+      non_executable_terms(value)
+      acc
+    end
+
+    :maps.fold(folder, map, map)
+  end
+
+  defp non_executable_terms(other)
+       when is_atom(other) or is_number(other) or is_bitstring(other) or is_pid(other) or
+              is_reference(other) do
+    other
+  end
+
+  defp non_executable_terms(other) do
+    raise ArgumentError,
+          "cannot deserialize #{inspect(other)}, the term is not safe for deserialization"
+  end
+
+  defp non_executable_list([]), do: :ok
+
+  defp non_executable_list([h | t]) when is_list(t) do
+    non_executable_terms(h)
+    non_executable_list(t)
+  end
+
+  defp non_executable_list([h | t]) do
+    non_executable_terms(h)
+    non_executable_terms(t)
+  end
+
+  defp non_executable_tuple(_tuple, 0), do: :ok
+
+  defp non_executable_tuple(tuple, n) do
+    non_executable_terms(:erlang.element(n, tuple))
+    non_executable_tuple(tuple, n - 1)
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule MessageQueue.MixProject do
   use Mix.Project
 
   @name "MessageQueue"
-  @version "0.3.4"
+  @version "0.3.5"
   @repo_url "https://github.com/ChannexIO/message_queue"
 
   def project do


### PR DESCRIPTION
This is restricted version of `:erlang.binary_to_term/2` that forbids *executable* terms, such as anonymous functions, copied from `Plug.Crypto`