### PR TITLE
Introduce RabbitMQ multiple producers

### DIFF
--- a/lib/message_queue/adapters/rabbitmq/process_registry.ex
+++ b/lib/message_queue/adapters/rabbitmq/process_registry.ex
@@ -1,0 +1,15 @@
+defmodule MessageQueue.Adapters.RabbitMQ.ProcessRegistry do
+  @moduledoc """
+  Helper for process registry managing.
+  """
+
+  @spec register(term(), term()) :: {:ok, pid()} | {:error, {:already_registered, pid()}}
+  def register(key, value) do
+    Registry.register(__MODULE__, key, value)
+  end
+
+  @spec lookup(term()) :: [{pid(), term()}]
+  def lookup(key) do
+    Registry.lookup(__MODULE__, key)
+  end
+end

--- a/lib/message_queue/adapters/rabbitmq/producer.ex
+++ b/lib/message_queue/adapters/rabbitmq/producer.ex
@@ -1,196 +1,100 @@
 defmodule MessageQueue.Adapters.RabbitMQ.Producer do
   @moduledoc false
 
+  use Supervisor
+
   @behaviour MessageQueue.Adapters.Producer
 
-  @reconnect_interval 10_000
+  alias MessageQueue.Adapters.RabbitMQ.{ProcessRegistry, ProducerWorker}
 
-  use AMQP
-  use GenServer
   require Logger
-  alias MessageQueue.{Message, Utils}
 
-  def start_link(_) do
-    GenServer.start_link(__MODULE__, nil, name: __MODULE__)
-  end
+  @default_workers_count 2
+  @workers_index_counter Module.concat(__MODULE__, WorkersIndexCounter)
 
-  @impl true
+  defguardp pos_integer(term) when is_integer(term) and term > 0
+
+  @impl MessageQueue.Adapters.Producer
   def publish(message, queue, options) do
-    GenServer.call(__MODULE__, {:publish, message, queue, options}, Utils.call_timeout())
+    ProducerWorker.request(get_worker(), {:publish, message, queue, options})
   end
 
-  @impl true
+  @impl MessageQueue.Adapters.Producer
   def delete_queue(queue, options) do
-    GenServer.call(__MODULE__, {:delete_queue, queue, options}, Utils.call_timeout())
+    ProducerWorker.request(get_worker(), {:delete_queue, queue, options})
   end
 
-  @impl true
-  def init(state) do
-    {:ok, state, {:continue, :connect}}
+  @doc false
+  def child_spec(opts) do
+    %{
+      id: __MODULE__,
+      type: :supervisor,
+      start: {__MODULE__, :start_link, [opts]}
+    }
   end
 
-  @impl true
-  def handle_continue(:connect, state) do
-    case MessageQueue.get_connection() do
-      {:ok, conn} ->
-        Process.monitor(conn.pid)
-        {:noreply, conn}
+  @doc false
+  def start_link(init_args) do
+    Supervisor.start_link(__MODULE__, init_args, name: __MODULE__)
+  end
 
-      {:error, _} ->
-        Logger.error("Failed to connect RabbitMQ. Reconnecting later...")
-        Process.sleep(@reconnect_interval)
-        {:noreply, state, {:continue, :connect}}
+  @impl Supervisor
+  def init(_init_arg) do
+    :ets.new(@workers_index_counter, [:public, :named_table])
+
+    children = [
+      {Registry, name: ProcessRegistry, keys: :duplicate},
+      set_workers_supervisor_specs()
+    ]
+
+    Supervisor.init(children, strategy: :rest_for_one)
+  end
+
+  defp set_workers_supervisor_specs do
+    workers_supervisor_name = Module.concat(__MODULE__, WorkersSupervisor)
+    workers_supervisor_options = [name: workers_supervisor_name, strategy: :one_for_one]
+
+    %{
+      id: workers_supervisor_name,
+      type: :supervisor,
+      start: {Supervisor, :start_link, [set_workers_specs(), workers_supervisor_options]}
+    }
+  end
+
+  defp set_workers_specs do
+    for index <- 1..get_workers_count() do
+      Supervisor.child_spec(ProducerWorker, id: {ProducerWorker, index})
     end
   end
 
-  @impl true
-  def handle_info({:DOWN, _, :process, _pid, reason}, _) do
-    {:stop, {:connection_lost, reason}, nil}
+  defp get_workers_count do
+    :message_queue
+    |> Application.get_env(:producer_workers_count)
+    |> format_workers_count()
   end
 
-  @impl true
-  def handle_info({_ref, {:ok, _connection}}, state) do
-    {:noreply, state}
-  end
-
-  @impl true
-  def handle_call({:publish, message, queue, options}, _, conn) do
-    case prepare_publish(conn, queue, options) do
-      {:ok, %{channel: channel, routing_key: routing_key, exchange: exchange}} ->
-        result = publish_message(channel, message, exchange, routing_key, options)
-        spawn(fn -> close_channel(channel) end)
-
-        {:reply, result, conn}
-
-      error ->
-        {:reply, error, conn}
+  defp format_workers_count(count) when is_binary(count) do
+    case Integer.parse(count) do
+      {count, ""} when count > 0 -> count
+      _ -> @default_workers_count
     end
   end
 
-  @impl true
-  def handle_call({:delete_queue, queue, options}, _, conn) do
-    with {:ok, channel} <- Channel.open(conn),
-         {:ok, _} <- Queue.delete(channel, queue, options) do
-      {:reply, :ok, conn}
-    else
-      error -> {:reply, error, conn}
-    end
+  defp format_workers_count(nil), do: @default_workers_count
+  defp format_workers_count(count) when pos_integer(count), do: count
+  defp format_workers_count(_count), do: @default_workers_count
+
+  defp get_worker do
+    workers = ProcessRegistry.lookup(:producer_workers)
+    workers_count = length(workers)
+    next_index = get_and_increment_worker_index(workers_count)
+    {pid, nil} = Enum.at(workers, rem(next_index, workers_count))
+    pid
   end
 
-  defp prepare_publish(conn, queue, options) do
-    with {:ok, channel} <- Channel.open(conn),
-         {:ok, exchange} <- get_exchange_name(queue, options),
-         {:ok, %{channel: channel, routing_key: routing_key}} <-
-           declare_and_bind_queue(exchange, channel, queue, options) do
-      {:ok, %{channel: channel, routing_key: routing_key, exchange: exchange}}
-    end
-  end
-
-  defp publish_message(channel, message, exchange, routing_key, options) do
-    with :ok <- Confirm.select(channel),
-         {:ok, encoded_message} <- encode_message(message, options),
-         :ok <- Basic.publish(channel, exchange, routing_key, encoded_message, options),
-         {:published, true} <- {:published, Confirm.wait_for_confirms(channel)} do
-      :ok
-    else
-      {:published, _} -> {:error, :not_published}
-      error -> error
-    end
-  end
-
-  defp get_exchange_type(queue, options) do
-    {_exchange_name, exchange_type} = get_exchange(queue, options)
-    {:ok, exchange_type}
-  end
-
-  defp get_exchange_name(queue, options) do
-    {exchange_name, _exchange_type} = get_exchange(queue, options)
-    {:ok, exchange_name}
-  end
-
-  defp get_exchange(queues, options) when is_list(queues) do
-    exchange_type = options[:exchange_type] || :fanout
-    exchange_name = options[:exchange] || "amq.#{exchange_type}"
-    {exchange_name, exchange_type}
-  end
-
-  defp get_exchange("" = _queue, options) do
-    default_type = if match?([_ | _], options[:headers]), do: :headers, else: :direct
-    exchange_type = options[:exchange_type] || default_type
-    exchange_name = options[:exchange] || "amq.#{exchange_type}"
-    {exchange_name, exchange_type}
-  end
-
-  defp get_exchange(_queue, options) do
-    exchange_type = options[:exchange_type] || :direct
-    exchange_name = options[:exchange] || "amq.#{exchange_type}"
-    {exchange_name, exchange_type}
-  end
-
-  defp declare_and_bind_queue("amq.headers", channel, _queue, _options) do
-    {:ok, %{routing_key: "", channel: channel}}
-  end
-
-  defp declare_and_bind_queue(exchange, channel, queues, options) do
-    if match?([_ | _], options[:headers]) do
-      {:ok, %{routing_key: "", channel: channel}}
-    else
-      declare_and_bind(exchange, channel, queues, options)
-    end
-  end
-
-  defp declare_and_bind(exchange, channel, queues, options) when is_list(queues) do
-    Enum.reduce_while(queues, {:ok, %{routing_key: "", channel: channel}}, fn queue, _acc ->
-      case declare_and_bind(exchange, channel, queue, options) do
-        {:ok, _} = result -> {:cont, result}
-        error -> {:halt, error}
-      end
-    end)
-  end
-
-  defp declare_and_bind(exchange, channel, queue, options) do
-    with {:ok, %{queue: queue}} <- Queue.declare(channel, queue, [{:passive, true} | options]),
-         routing_key <- Keyword.get(options, :routing_key, queue),
-         :ok <- Queue.bind(channel, queue, exchange, routing_key: routing_key) do
-      {:ok, %{routing_key: routing_key, channel: channel}}
-    else
-      error ->
-        spawn(fn -> close_channel(channel) end)
-        error
-    end
-  catch
-    :exit, {{:shutdown, {:server_initiated_close, 404, "NOT_FOUND - no queue" <> _}}, _} ->
-      redeclare_and_bind_queue(exchange, channel, queue, options)
-  end
-
-  defp redeclare_and_bind_queue(exchange, channel, queue, options) do
-    case Channel.open(channel.conn) do
-      {:ok, channel} ->
-        with {:ok, exchange_type} <- get_exchange_type(queue, options),
-             :ok <- Exchange.declare(channel, exchange, exchange_type, options),
-             {:ok, %{queue: queue}} <- Queue.declare(channel, queue, options),
-             routing_key <- Keyword.get(options, :routing_key, queue),
-             :ok <- Queue.bind(channel, queue, exchange, routing_key: routing_key) do
-          {:ok, %{routing_key: routing_key, channel: channel}}
-        else
-          error ->
-            spawn(fn -> close_channel(channel) end)
-            error
-        end
-
-      error ->
-        error
-    end
-  end
-
-  defp encode_message(message, opts) do
-    Message.encode(message,
-      type: opts[:message_type],
-      parser_opts: opts[:message_parser_opts] || []
-    )
-  end
-
-  defp close_channel(channel) do
-    Channel.close(channel)
+  defp get_and_increment_worker_index(workers_count) do
+    default = {_value_pos = 2, _default_value = -1}
+    update_operation = {_value_pos = 2, _incr = 1, _threshold = workers_count, _set_value = 1}
+    :ets.update_counter(@workers_index_counter, :worker_index, update_operation, default)
   end
 end

--- a/lib/message_queue/adapters/rabbitmq/producer_worker.ex
+++ b/lib/message_queue/adapters/rabbitmq/producer_worker.ex
@@ -1,0 +1,193 @@
+defmodule MessageQueue.Adapters.RabbitMQ.ProducerWorker do
+  @moduledoc false
+
+  @reconnect_interval 10_000
+
+  use AMQP
+  use GenServer
+
+  require Logger
+
+  alias MessageQueue.Adapters.RabbitMQ.ProcessRegistry
+  alias MessageQueue.{Message, Utils}
+
+  @doc false
+  def request(pid, request) do
+    GenServer.call(pid, request, Utils.call_timeout())
+  end
+
+  @doc false
+  def start_link(init_arg) do
+    GenServer.start_link(__MODULE__, init_arg, hibernate_after: 15_000)
+  end
+
+  @impl GenServer
+  def init(state) do
+    {:ok, state, {:continue, :connect}}
+  end
+
+  @impl GenServer
+  def handle_continue(:connect, state) do
+    case MessageQueue.get_connection() do
+      {:ok, conn} ->
+        ProcessRegistry.register(:producer_workers, nil)
+        Process.monitor(conn.pid)
+        {:noreply, conn}
+
+      {:error, _} ->
+        Logger.error("Failed to connect RabbitMQ. Reconnecting later...")
+        Process.sleep(@reconnect_interval)
+        {:noreply, state, {:continue, :connect}}
+    end
+  end
+
+  @impl GenServer
+  def handle_info({:DOWN, _, :process, _pid, reason}, _) do
+    {:stop, {:connection_lost, reason}, nil}
+  end
+
+  @impl GenServer
+  def handle_info({_ref, {:ok, _connection}}, state) do
+    {:noreply, state}
+  end
+
+  @impl GenServer
+  def handle_call({:publish, message, queue, options}, _, conn) do
+    case prepare_publish(conn, queue, options) do
+      {:ok, %{channel: channel, routing_key: routing_key, exchange: exchange}} ->
+        result = publish_message(channel, message, exchange, routing_key, options)
+        Task.start(fn -> :ok = close_channel(channel) end)
+        {:reply, result, conn}
+
+      error ->
+        {:reply, error, conn}
+    end
+  end
+
+  @impl GenServer
+  def handle_call({:delete_queue, queue, options}, _, conn) do
+    with {:ok, channel} <- Channel.open(conn),
+         {:ok, _} <- Queue.delete(channel, queue, options) do
+      {:reply, :ok, conn}
+    else
+      error -> {:reply, error, conn}
+    end
+  end
+
+  defp prepare_publish(conn, queue, options) do
+    with {:ok, channel} <- Channel.open(conn),
+         {:ok, exchange} <- get_exchange_name(queue, options),
+         {:ok, %{channel: channel, routing_key: routing_key}} <-
+           declare_and_bind_queue(exchange, channel, queue, options) do
+      {:ok, %{channel: channel, routing_key: routing_key, exchange: exchange}}
+    end
+  end
+
+  defp publish_message(channel, message, exchange, routing_key, options) do
+    with :ok <- Confirm.select(channel),
+         {:ok, encoded_message} <- encode_message(message, options),
+         :ok <- Basic.publish(channel, exchange, routing_key, encoded_message, options),
+         {:published, true} <- {:published, Confirm.wait_for_confirms(channel)} do
+      :ok
+    else
+      {:published, _} -> {:error, :not_published}
+      error -> error
+    end
+  end
+
+  defp get_exchange_type(queue, options) do
+    {_exchange_name, exchange_type} = get_exchange(queue, options)
+    {:ok, exchange_type}
+  end
+
+  defp get_exchange_name(queue, options) do
+    {exchange_name, _exchange_type} = get_exchange(queue, options)
+    {:ok, exchange_name}
+  end
+
+  defp get_exchange(queues, options) when is_list(queues) do
+    exchange_type = options[:exchange_type] || :fanout
+    exchange_name = options[:exchange] || "amq.#{exchange_type}"
+    {exchange_name, exchange_type}
+  end
+
+  defp get_exchange("" = _queue, options) do
+    default_type = if match?([_ | _], options[:headers]), do: :headers, else: :direct
+    exchange_type = options[:exchange_type] || default_type
+    exchange_name = options[:exchange] || "amq.#{exchange_type}"
+    {exchange_name, exchange_type}
+  end
+
+  defp get_exchange(_queue, options) do
+    exchange_type = options[:exchange_type] || :direct
+    exchange_name = options[:exchange] || "amq.#{exchange_type}"
+    {exchange_name, exchange_type}
+  end
+
+  defp declare_and_bind_queue("amq.headers", channel, _queue, _options) do
+    {:ok, %{routing_key: "", channel: channel}}
+  end
+
+  defp declare_and_bind_queue(exchange, channel, queues, options) do
+    if match?([_ | _], options[:headers]) do
+      {:ok, %{routing_key: "", channel: channel}}
+    else
+      declare_and_bind(exchange, channel, queues, options)
+    end
+  end
+
+  defp declare_and_bind(exchange, channel, queues, options) when is_list(queues) do
+    Enum.reduce_while(queues, {:ok, %{routing_key: "", channel: channel}}, fn queue, _acc ->
+      case declare_and_bind(exchange, channel, queue, options) do
+        {:ok, _} = result -> {:cont, result}
+        error -> {:halt, error}
+      end
+    end)
+  end
+
+  defp declare_and_bind(exchange, channel, queue, options) do
+    with {:ok, %{queue: queue}} <- Queue.declare(channel, queue, [{:passive, true} | options]),
+         routing_key <- Keyword.get(options, :routing_key, queue),
+         :ok <- Queue.bind(channel, queue, exchange, routing_key: routing_key) do
+      {:ok, %{routing_key: routing_key, channel: channel}}
+    else
+      error ->
+        Task.start(fn -> :ok = close_channel(channel) end)
+        error
+    end
+  catch
+    :exit, {{:shutdown, {:server_initiated_close, 404, "NOT_FOUND - no queue" <> _}}, _} ->
+      redeclare_and_bind_queue(exchange, channel, queue, options)
+  end
+
+  defp redeclare_and_bind_queue(exchange, channel, queue, options) do
+    case Channel.open(channel.conn) do
+      {:ok, channel} ->
+        with {:ok, exchange_type} <- get_exchange_type(queue, options),
+             :ok <- Exchange.declare(channel, exchange, exchange_type, options),
+             {:ok, %{queue: queue}} <- Queue.declare(channel, queue, options),
+             routing_key <- Keyword.get(options, :routing_key, queue),
+             :ok <- Queue.bind(channel, queue, exchange, routing_key: routing_key) do
+          {:ok, %{routing_key: routing_key, channel: channel}}
+        else
+          error ->
+            Task.start(fn -> :ok = close_channel(channel) end)
+            error
+        end
+
+      error ->
+        error
+    end
+  end
+
+  defp encode_message(message, opts) do
+    Message.encode(message,
+      type: opts[:message_type],
+      parser_opts: opts[:message_parser_opts] || []
+    )
+  end
+
+  defp close_channel(channel) do
+    Channel.close(channel)
+  end
+end

--- a/lib/message_queue/adapters/sandbox/producer.ex
+++ b/lib/message_queue/adapters/sandbox/producer.ex
@@ -5,6 +5,15 @@ defmodule MessageQueue.Adapters.Sandbox.Producer do
 
   use GenServer
 
+  @doc false
+  def child_spec(opts) do
+    %{
+      id: __MODULE__,
+      start: {__MODULE__, :start_link, [opts]}
+    }
+  end
+
+  @doc false
   def start_link(_) do
     GenServer.start_link(__MODULE__, nil, name: __MODULE__)
   end

--- a/lib/message_queue/producer.ex
+++ b/lib/message_queue/producer.ex
@@ -4,10 +4,7 @@ defmodule MessageQueue.Producer do
   """
 
   def child_spec(opts) do
-    %{
-      id: MessageQueue.producer(),
-      start: {MessageQueue.producer(), :start_link, [opts]}
-    }
+    MessageQueue.producer().child_spec(opts)
   end
 
   def publish(message, queue, options) do


### PR DESCRIPTION
Changed `MessageQueue.Adapters.RabbitMQ.Producer` type to supervisor, which now distributes requests to workers (by default 2 workers) by naive round-robin algorithm. The number of workers is configured with `:producer_workers_count` config key.