### PR TITLE
Return channel to RabbitMQ adapter ProducerWorker state

### DIFF
--- a/lib/message_queue/adapters/rabbitmq/producer_worker.ex
+++ b/lib/message_queue/adapters/rabbitmq/producer_worker.ex
@@ -35,7 +35,7 @@ defmodule MessageQueue.Adapters.RabbitMQ.ProducerWorker do
       ProcessRegistry.register(:producer_workers, chan)
       Process.monitor(conn.pid)
       Process.monitor(chan.pid)
-      {:noreply, state}
+      {:noreply, %{chan: chan}}
     else
       {:error, _} ->
         Logger.error("Failed to connect RabbitMQ. Reconnecting later...")


### PR DESCRIPTION
Problem: we do not pre declare queue but declare it on publish only if not declared before and do it by catching basic return specific message and need channel to declare queue and republish the message

Solution: keep channel in ProducerWorker state to use in NO_ROUTE case