### PR TITLE
Put additional logging on publish retry/producer connect

### DIFF
--- a/lib/message_queue/adapters/rabbitmq/producer_worker.ex
+++ b/lib/message_queue/adapters/rabbitmq/producer_worker.ex
@@ -46,20 +46,6 @@ defmodule MessageQueue.Adapters.RabbitMQ.ProducerWorker do
   end
 
   @impl true
-  def handle_info({:DOWN, _ref, :process, pid, reason}, %{chan: %{pid: pid}, conn: conn}) do
-    case Channel.open(conn) do
-      {:ok, chan} ->
-        Logger.warning(
-          "[ProducerWorker] reopen channel on :DOWN #{inspect(conn.pid)} #{inspect(chan.pid)}"
-        )
-
-        {:noreply, %{conn: conn, chan: chan}}
-
-      _ ->
-        {:stop, {:connection_lost, reason}, nil}
-    end
-  end
-
   def handle_info({:DOWN, _ref, :process, _pid, reason}, _state) do
     {:stop, {:connection_lost, reason}, nil}
   end

--- a/lib/message_queue/utils.ex
+++ b/lib/message_queue/utils.ex
@@ -75,4 +75,18 @@ defmodule MessageQueue.Utils do
       {:error, _error} -> NimbleOptions.validate!([], @producer_retry_opts_schema)
     end
   end
+
+  @doc false
+  def interpolate_template(template, values) when is_binary(template) and is_map(values) do
+    String.replace(template, ~r/\$(\w+)/, fn "$" <> key ->
+      case Map.fetch(values, String.to_atom(key)) do
+        {:ok, val} -> safe_to_string(val)
+        :error -> "$#{key}"
+      end
+    end)
+  end
+
+  defp safe_to_string(term) do
+    if String.Chars.impl_for(term), do: to_string(term), else: inspect(term)
+  end
 end


### PR DESCRIPTION
Just few logs that will show
- when ProducerWorker actually established connection
- message id that will allow to track message life in terms of repeats